### PR TITLE
Minor bugfix: Incorrect capitalisation in references to "LinksAndMetadata.tex"

### DIFF
--- a/Main.tex
+++ b/Main.tex
@@ -66,7 +66,7 @@
 % Sets up links within your document, for e.g. contents page entries
 %  and references, and also PDF metadata.
 % You should edit this!
-\input{LinksAndMetaData}
+\input{LinksAndMetadata}
 
 % And then some settings in separate files.
 \input{FloatSettings} % For things like figures and tables

--- a/mphil-thesis.tex
+++ b/mphil-thesis.tex
@@ -66,7 +66,7 @@
 % Sets up links within your document, for e.g. contents page entries
 %  and references, and also PDF metadata.
 % You should edit this!
-\input{LinksAndMetaData}
+\input{LinksAndMetadata}
 
 % And then some settings in separate files.
 \input{FloatSettings} % For things like figures and tables

--- a/mres-thesis.tex
+++ b/mres-thesis.tex
@@ -66,7 +66,7 @@
 % Sets up links within your document, for e.g. contents page entries
 %  and references, and also PDF metadata.
 % You should edit this!
-\input{LinksAndMetaData}
+\input{LinksAndMetadata}
 
 % And then some settings in separate files.
 \input{FloatSettings} % For things like figures and tables

--- a/phd-thesis-twoside.tex
+++ b/phd-thesis-twoside.tex
@@ -66,7 +66,7 @@
 % Sets up links within your document, for e.g. contents page entries
 %  and references, and also PDF metadata.
 % You should edit this!
-\input{LinksAndMetaData}
+\input{LinksAndMetadata}
 
 % And then some settings in separate files.
 \input{FloatSettings} % For things like figures and tables

--- a/phd-thesis.tex
+++ b/phd-thesis.tex
@@ -66,7 +66,7 @@
 % Sets up links within your document, for e.g. contents page entries
 %  and references, and also PDF metadata.
 % You should edit this!
-\input{LinksAndMetaData}
+\input{LinksAndMetadata}
 
 % And then some settings in separate files.
 \input{FloatSettings} % For things like figures and tables


### PR DESCRIPTION
replacement of "LinksAndMetaData" with "LinksAndMetadata" in the
following .tex files:
* Main.tex
* mphil-thesis.tex
* mres-thesis.tex
* phd-thesis-twoside.tex
* phd-thesis.tex

The capitalisation mismatch between the filename and the reference in the
modified files causes a compilation failure on linux