### PR TITLE
Updated Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,11 @@
-language: c
-
+before_install:
+   - sudo add-apt-repository -y ppa:texlive-backports/ppa
+   - sudo apt-get update
 install:
-  - mkdir -p /tmp/texlive && cd /tmp/texlive && wget https://gist.github.com/urdh/ca8ffcf7cb7c6eace9ad/raw/57718dd299f2e0cd4a2966c17222330624ec9383/texlive.profile
-  - wget http://mirror.ctan.org/systems/texlive/tlnet/install-tl-unx.tar.gz && tar -xvf install-tl-unx.tar.gz && cd install-tl-* && sudo ./install-tl --profile=../texlive.profile
-  - cd $TRAVIS_BUILD_DIR && export PATH=/usr/local/texlive/CURRENT/bin/x86_64-linux:$PATH
-
+   - sudo apt-get install -y texlive-latex-base
+   - sudo apt-get install -y texlive-latex-recommended texlive-latex-extra
+   - sudo apt-get install -y texlive-science
+   - sudo apt-get install -y texlive-fonts-recommended texlive-fonts-extra
+   - sudo apt-get install -y psutils
 script:
-  - make
+   - make

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # UCL LaTeX Thesis Templates
 
-_Unfortunately I've had to disable tests while I try to work out a way to get a TeX installation with all the necessary packages onto the testing image without it taking forever. Please ignore the test image for now:_
 [![Build Status](https://travis-ci.org/UCL/ucl-latex-thesis-templates.svg?branch=master)](https://travis-ci.org/UCL/ucl-latex-thesis-templates)
 
 This is a skeletal thesis template with a class and .sty file that you can use separately if you'd prefer.
@@ -25,4 +24,3 @@ and then get links that don't work in the PDF, try un-commenting the line below 
 ```latex
 \usepackage{natbib}
 ```
-


### PR DESCRIPTION
[![Build Status](https://travis-ci.org/Alghamdi/ucl-latex-thesis-templates.svg?branch=master)](https://travis-ci.org/Alghamdi/ucl-latex-thesis-templates)
Build now passes, however, its running on Travis legacy infrastructure. Once Travis whitelist the [required package](https://github.com/travis-ci/apt-source-whitelist/issues/99) we can migrate to container-based infrastructure.