### PR TITLE
Added 'Impact Statement' environment

### DIFF
--- a/Preamble.tex
+++ b/Preamble.tex
@@ -21,6 +21,34 @@ It begins with a study of some stuff, and then some other stuff and things.
 There is a 300-word limit on your abstract.
 \end{abstract}
 
+\begin{impactstatement}
+The statement should describe, in no more than 500 words, how the expertise, knowledge, analysis,
+discovery or insight presented in your thesis could be put to a beneficial use. Consider benefits both
+inside and outside academia and the ways in which these benefits could be brought about.
+
+The benefits inside academia could be to the discipline and future scholarship, research methods or
+methodology, the curriculum; they might be within your research area and potentially within other
+research areas.
+
+The benefits outside academia could occur to commercial activity, social enterprise, professional
+practice, clinical use, public health, public policy design, public service delivery, laws, public
+discourse, culture, the quality of the environment or quality of life.
+
+The impact could occur locally, regionally, nationally or internationally, to individuals, communities or
+organisations and could be immediate or occur incrementally, in the context of a broader field of
+research, over many years, decades or longer.
+
+Impact could be brought about through disseminating outputs (either in scholarly journals or
+elsewhere such as specialist or mainstream media), education, public engagement, translational
+research, commercial and social enterprise activity, engaging with public policy makers and public
+service delivery practitioners, influencing ministers, collaborating with academics and non-academics
+etc.
+
+Further information including a searchable list of hundreds of examples of UCL impact outside of
+academia please see \url{https://www.ucl.ac.uk/impact/}. For thousands more examples, please see
+\url{http://results.ref.ac.uk/Results/SelectUoa}.
+\end{impactstatement}
+
 \begin{acknowledgements}
 Acknowledge all the things!
 \end{acknowledgements}

--- a/ucl_thesis.cls
+++ b/ucl_thesis.cls
@@ -557,6 +557,17 @@
 }
 %    \end{macrocode}
 %  \end{environment}
+%  \begin{environment}{impact statement}
+%  An environment for the Impact Statement
+%    \begin{macrocode}
+\newcommand \@impactstatement{Impact Statement}
+\newenvironment{impactstatement}{%
+    \chapter*{\@impactstatement}%
+    \@mkboth{\@impactstatement}{\@impactstatement}%
+}{%
+}
+%    \end{macrocode}
+%  \end{environment}
 %  \Finale
 \endinput
 %%


### PR DESCRIPTION
UCL theses now require an Impact Statement, following the Abstract:
https://www.ucl.ac.uk/students/exams-and-assessments/research-assessments/format-bind-and-submit-your-thesis-general-guidance

Minor fix adds an 'impactstatement' environment, with content description in the environment implementation.