### PR TITLE
Update TOC links

### DIFF
--- a/Appendices.tex
+++ b/Appendices.tex
@@ -1,3 +1,4 @@
+\phantomsection
 \addcontentsline{toc}{chapter}{Appendices}
 
 % The \appendix command resets the chapter counter, and changes the chapter numbering scheme to capital letters.

--- a/Main.tex
+++ b/Main.tex
@@ -105,14 +105,12 @@
 % You could separate these out into different files if you have
 %  particularly large appendices.
 
-% This line manually adds the Bibliography to the table of contents.
-% The fact that \include is the last thing before this ensures that it
-% is on a clear page, and adding it like this means that it doesn't
-% get a chapter or appendix number.
-\addcontentsline{toc}{chapter}{Bibliography}
-
-% Actually generates your bibliography.
+% Actually generates your bibliography. The fact that \include is 
+% the last thing before this ensures that it is on a clear page.
 \bibliography{example}
+% This line manually adds the Bibliography to the table of contents. 
+% Adding it like this means that it doesn't get a chapter or appendix number.
+\addcontentsline{toc}{chapter}{Bibliography}
 
 % All done. \o/
 \end{document}


### PR DESCRIPTION
@ikirker - Unrelated to our other discussions, I've made a couple of tweaks that fix links from the TOC to the Bibliography and Appendices.

Different tactics used for each: 
For bib- I just moved the addcontentsline to after the bib was generated.
For appendices I added a \phantomsection.