### PR TITLE
Remove obsolete times font package

### DIFF
--- a/ucl_thesis.cls
+++ b/ucl_thesis.cls
@@ -156,7 +156,6 @@
 \DeclareOption*{\PassOptionsToClass{\CurrentOption}{book}}
 \ProcessOptions
 \LoadClass{book}
-\RequirePackage{times}
 \RequirePackage{mathptmx}
 %    \end{macrocode}
 %


### PR DESCRIPTION
Fixes Issue #14 by removing obsolete `times` package and using `mathptmx` instead.

As described [here on CTAN](https://ctan.org/pkg/times) the `times` package is indeed replaced by the `mathptmx` package which was already used in this template.