### PR TITLE
Add a part command and fix one column

### DIFF
--- a/Main.tex
+++ b/Main.tex
@@ -78,8 +78,6 @@
 
 
 \begin{document}
-% This is a workardoud to get hbar to work with the thesis class and amssymb
-\renewcommand{\hbar}{\mathchar'26\mkern-9mu h}
 
 \nobibliography*
 % ^-- This is a dumb trick that works with the bibentry package to let

--- a/Main.tex
+++ b/Main.tex
@@ -78,6 +78,8 @@
 
 
 \begin{document}
+% This is a workardoud to get hbar to work with the thesis class and amssymb
+\renewcommand{\hbar}{\mathchar'26\mkern-9mu h}
 
 \nobibliography*
 % ^-- This is a dumb trick that works with the bibentry package to let

--- a/ucl_thesis.cls
+++ b/ucl_thesis.cls
@@ -489,7 +489,30 @@
 %  Redefine the chapter and section commands in order to change the font of the section heads.
 %  Only include in contents and number down to subsections.
 %    \begin{macrocode}
+
+\renewcommand \part{%
+    \if@twocolumn%
+        \@restonecoltrue \onecolumn%
+    \else%
+        \@restonecolfalse%
+    \fi%
+    \if@openright%
+        \cleardoublepage%
+    \else%
+        \clearpage%
+    \fi
+    \thispagestyle{empty}%
+    \global \@topnum \z@%
+    \@afterindentfalse%
+    \secdef \@part \@spart%
+}
+
 \renewcommand \chapter{%
+    \if@twocolumn%
+        \@restonecolfalse%
+    \else%
+        \@restonecoltrue%
+    \fi%
     \if@openright%
         \cleardoublepage%
     \else%


### PR DESCRIPTION
Some theses may require a part command to separate groups of chapters - I have added the part command to reflect the rest of the document.

Also, when using BibLatex, as opposed to bibtex I found that this broke the onecolumn setting of the class. I have copied the code sen in the contents to ensure that everything after part and chapter also appears as one column.